### PR TITLE
ci: cache dependencies to speed up builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,11 +15,12 @@ jobs:
     - name: Checkout source code
       uses: actions/checkout@v5
 
-    - name: Set up dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y autoconf automake libtool xsltproc docbook-xsl \
-          libxpm-dev libx11-dev libxinerama-dev
+    - name: Install and cache dependencies
+      uses: awalsh128/cache-apt-pkgs-action@v1
+      with:
+        packages: >
+          autoconf automake libtool xsltproc docbook-xsl libxpm-dev libx11-dev
+          libxinerama-dev
 
     - name: Run autoreconf
       run: autoreconf --install


### PR DESCRIPTION
Cache dependencies in GitHub Actions to speed up build times for CI.
