### PR TITLE
correctly handle -0 in xinerama_update_geometry

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
   'stalonetray',
   'c',
-  version: '1.0.0',
+  version: '1.0.1',
   default_options: ['warning_level=3', 'c_std=gnu23'],
   meson_version: '>=1.1.0',
 )

--- a/src/xinerama.c
+++ b/src/xinerama.c
@@ -34,26 +34,26 @@ void xinerama_update_geometry(void)
 #ifdef _ST_WITH_XINERAMA
     XineramaScreenInfo chosen_monitor;
     unsigned int dummy;
-    int x, y;
+    int x, y, flags;
 
     if (!tray_data.xinerama_active)
         return;
 
     LOG_TRACE(("Updating geometry based on chosen Xinerama monitor\n"));
 
-    XParseGeometry(settings.geometry_str, &x, &y, &dummy, &dummy);
+    flags = XParseGeometry(settings.geometry_str, &x, &y, &dummy, &dummy);
     chosen_monitor = tray_data.monitors[settings.monitor];
 
     LOG_TRACE(("Chosen monitor %d: %dx%d+%d+%d\n", settings.monitor,
         chosen_monitor.width, chosen_monitor.height, chosen_monitor.x_org,
         chosen_monitor.y_org));
 
-    if (x < 0)
+    if (x < 0 || flags & XNegative)
         tray_data.xsh.x = chosen_monitor.x_org + chosen_monitor.width + x - tray_data.xsh.width;
     else
         tray_data.xsh.x = chosen_monitor.x_org + x;
 
-    if (y < 0)
+    if (y < 0 || flags & YNegative)
         tray_data.xsh.y = chosen_monitor.y_org + chosen_monitor.height + y - tray_data.xsh.height;
     else
         tray_data.xsh.y = chosen_monitor.y_org + y;


### PR DESCRIPTION
the return value of `XParseGeometry` must be checked when handling `-0` to align from the right or bottom of the screen

perhaps we should also assert that the values are also present, or assign them to be 0 as a default, because it is not guaranteed that the geometry setting is `wxh+x+y`