### PR TITLE
fix: enable trace logging without debug symbol

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
   'stalonetray',
   'c',
-  version: '1.0.1',
+  version: '1.0.2',
   default_options: ['warning_level=3', 'c_std=gnu23'],
   meson_version: '>=1.1.0',
 )

--- a/src/debug.c
+++ b/src/debug.c
@@ -80,9 +80,9 @@ int print_icon_data(struct TrayIcon *ti)
     XWindowAttributes xwa;
 #endif
     LOG_INFO(("wid = 0x%lx\n", ti->wid));
-    LOG_TRACE(("  self = %p\n", ti));
-    LOG_TRACE(("  prev = %p\n", ti->prev));
-    LOG_TRACE(("  next = %p\n", ti->next));
+    LOG_TRACE(("  self = %p\n", (void *) ti));
+    LOG_TRACE(("  prev = %p\n", (void *) ti->prev));
+    LOG_TRACE(("  next = %p\n", (void *) ti->next));
     LOG_TRACE(("  invalid = %d\n", ti->is_invalid));
     LOG_TRACE(("  layed_out = %d\n", ti->is_layed_out));
     LOG_TRACE(("  update_pos = %d\n", ti->is_updated));

--- a/src/debug.c
+++ b/src/debug.c
@@ -39,8 +39,6 @@ void print_message_to_stderr(const char *fmt, ...)
     fprintf(stderr, "%s", msg);
 }
 
-#ifdef DEBUG
-
 int trace_mode = False;
 
 void print_trace_header(
@@ -74,7 +72,6 @@ void print_trace_header(
 #endif
     fprintf(stderr, "%s(): ", funcname);
 }
-#endif
 
 /* Print the summary of icon data */
 int print_icon_data(struct TrayIcon *ti)

--- a/src/debug.c
+++ b/src/debug.c
@@ -71,6 +71,10 @@ void print_trace_header(
     fprintf(stderr, "(%s:%4d) ", fname, line);
 #endif
     fprintf(stderr, "%s(): ", funcname);
+
+    (void) pid; /* unused */
+    (void) fname; /* unused */
+    (void) line; /* unused */
 }
 
 /* Print the summary of icon data */

--- a/src/debug.h
+++ b/src/debug.h
@@ -36,8 +36,8 @@ void print_message_to_stderr(const char *fmt, ...)
 #endif
     ;
 
-#ifdef DEBUG
 /* The following defines control what is printed in each logged line */
+#ifdef DEBUG
 /* Print window name */
 #define TRACE_WM_NAME
 /* Print pid */
@@ -49,6 +49,8 @@ void print_message_to_stderr(const char *fmt, ...)
 /* Print name of a function, file and line which outputs the message */
 /* Othewise, only function name is printed */
 #undef TRACE_VERBOSE_LOCATION
+#endif
+
 /* Print the debug header as specified by defines below */
 void print_trace_header(
     const char *funcname, const char *fname, const int line);
@@ -65,14 +67,6 @@ void print_trace_header(
             print_message_to_stderr message; \
         }; \
     } while (0)
-#else
-#define PRINT_TRACE_HEADER() \
-    do { \
-    } while (0)
-#define LOG_TRACE(message) \
-    do { \
-    } while (0)
-#endif
 
 #define LOG_ERROR(message) \
     do { \

--- a/src/main.c
+++ b/src/main.c
@@ -966,7 +966,7 @@ int main(int argc, char **argv)
     if ((tray_data.dpy = XOpenDisplay(settings.display_str)) == NULL)
         DIE(("could not open display\n"));
     else
-        LOG_TRACE(("Opened dpy %p\n", tray_data.dpy));
+        LOG_TRACE(("Opened dpy %p\n", (void *) tray_data.dpy));
 #ifdef _ST_EXIT_GRACEFULLY
     if ((async_dpy = XOpenDisplay(settings.display_str)) == NULL)
         DIE(("could not open display\n"));

--- a/src/settings.c
+++ b/src/settings.c
@@ -121,10 +121,8 @@ int parse_log_level(int, const char **argv, void **references, int silent)
         *log_level = LOG_LEVEL_ERR;
     else if (!strcmp(argv[0], "info"))
         *log_level = LOG_LEVEL_INFO;
-#ifdef DEBUG
     else if (!strcmp(argv[0], "trace"))
         *log_level = LOG_LEVEL_TRACE;
-#endif
     else {
         PARSING_ERROR("err, info, or trace expected", argv[0]);
         return FAILURE;

--- a/src/xembed.c
+++ b/src/xembed.c
@@ -286,7 +286,7 @@ void xembed_switch_focus_to(struct TrayIcon *tgt, long focus)
     if (tray_data.xembed_data.current != NULL) {
         LOG_TRACE(("XEMBED focus was removed from icon 0x%lx (pointer %p)\n",
             tray_data.xembed_data.current->wid,
-            tray_data.xembed_data.current));
+            (void *) tray_data.xembed_data.current));
         xembed_send_focus_out(tray_data.dpy,
             tray_data.xembed_data.current->wid,
             tray_data.xembed_data.timestamp);
@@ -296,7 +296,7 @@ void xembed_switch_focus_to(struct TrayIcon *tgt, long focus)
         xembed_send_focus_in(
             tray_data.dpy, tgt->wid, focus, tray_data.xembed_data.timestamp);
         LOG_TRACE(("XEMBED focus was set to icon 0x%lx (pointer %p)\n",
-            tgt->wid, tgt));
+            tgt->wid, (void *) tgt));
     } else {
         LOG_TRACE(("XEMBED focus was unset\n"));
     }


### PR DESCRIPTION
Reenables trace logs without the need for the `DEBUG` macro, which is no longer
defined for release builds.

Commits:

- **fix: enable trace logs without debug macro**
- **refactor: eliminate format warnings for pointers**
- **refactor: eliminate unused variable warnings**

Fixes #57.
