### PR TITLE
xinerama: Parse geometry with missing components

### DIFF
--- a/src/xinerama.c
+++ b/src/xinerama.c
@@ -48,15 +48,22 @@ void xinerama_update_geometry(void)
         chosen_monitor.width, chosen_monitor.height, chosen_monitor.x_org,
         chosen_monitor.y_org));
 
-    if (x < 0 || flags & XNegative)
-        tray_data.xsh.x = chosen_monitor.x_org + chosen_monitor.width + x - tray_data.xsh.width;
-    else
+    if (flags & XValue) {
+      if (!(flags & XNegative))
         tray_data.xsh.x = chosen_monitor.x_org + x;
+      else
+        tray_data.xsh.x = chosen_monitor.x_org + chosen_monitor.width + x - tray_data.xsh.width;
+    } else
+        tray_data.xsh.x = chosen_monitor.x_org;
 
-    if (y < 0 || flags & YNegative)
-        tray_data.xsh.y = chosen_monitor.y_org + chosen_monitor.height + y - tray_data.xsh.height;
-    else
+    if (flags & YValue) {
+      if (!(flags & YNegative))
         tray_data.xsh.y = chosen_monitor.y_org + y;
+      else
+        tray_data.xsh.y = chosen_monitor.y_org + chosen_monitor.height + y - tray_data.xsh.height;
+    }
+    else
+        tray_data.xsh.y = chosen_monitor.y_org;
 
     LOG_TRACE(("New tray position (x,y): %d,%d\n", tray_data.xsh.x, tray_data.xsh.y));
 #else

--- a/src/xinerama.c
+++ b/src/xinerama.c
@@ -34,7 +34,7 @@ void xinerama_update_geometry(void)
 #ifdef _ST_WITH_XINERAMA
     XineramaScreenInfo chosen_monitor;
     unsigned int dummy;
-    int x, y, flags;
+    int x = 0, y = 0, flags;
 
     if (!tray_data.xinerama_active)
         return;
@@ -48,22 +48,13 @@ void xinerama_update_geometry(void)
         chosen_monitor.width, chosen_monitor.height, chosen_monitor.x_org,
         chosen_monitor.y_org));
 
-    if (flags & XValue) {
-      if (!(flags & XNegative))
-        tray_data.xsh.x = chosen_monitor.x_org + x;
-      else
-        tray_data.xsh.x = chosen_monitor.x_org + chosen_monitor.width + x - tray_data.xsh.width;
-    } else
-        tray_data.xsh.x = chosen_monitor.x_org;
+    if (flags & XValue && flags & XNegative)
+        x += chosen_monitor.width - tray_data.xsh.width;
+    if (flags & YValue && flags & YNegative)
+        y += chosen_monitor.height - tray_data.xsh.height;
 
-    if (flags & YValue) {
-      if (!(flags & YNegative))
-        tray_data.xsh.y = chosen_monitor.y_org + y;
-      else
-        tray_data.xsh.y = chosen_monitor.y_org + chosen_monitor.height + y - tray_data.xsh.height;
-    }
-    else
-        tray_data.xsh.y = chosen_monitor.y_org;
+    tray_data.xsh.x = chosen_monitor.x_org + x;
+    tray_data.xsh.y = chosen_monitor.y_org + y;
 
     LOG_TRACE(("New tray position (x,y): %d,%d\n", tray_data.xsh.x, tray_data.xsh.y));
 #else


### PR DESCRIPTION
X11 geometry specification allows for x or y components to be missing, in which case, as specified in the `XParseGeometry` documentation, corresponding pointer is not updated. While it is a bit of a niece case, it seems better to avoid reading undefined values.

For example, a geometry of "32x1" is a valid geometry for the tray, indicating an upper left position.  And a geometry of "32x1-0" is a valid geometry indicating an upper right position.