### PR TITLE
fix: enable graceful exit hack by default

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
   'stalonetray',
   'c',
-  version: '1.0.2',
+  version: '1.0.3',
   default_options: ['warning_level=3', 'c_std=gnu23'],
   meson_version: '>=1.1.0',
 )

--- a/meson.options
+++ b/meson.options
@@ -11,5 +11,5 @@ option('delay_embedding_confirmation', type: 'boolean', value: false,
   description: 'Delay sending XEMBED_EMBEDDED_NOTIFY message for debugging')
 option('dump_window_information', type: 'boolean', value: false,
   description: 'Use xprop/xwininfo to dump icon window information')
-option('exit_gracefully', type: 'boolean', value: false,
+option('exit_gracefully', type: 'boolean', value: true,
   description: 'Use non-portable hack to exit gracefully on signal')


### PR DESCRIPTION
Enable graceful exit hack by default, which was the case previously when
built using GNU Autotools.

Resolves #53.
