### PR TITLE
Add symlink

### DIFF
--- a/generate-manpage.sh
+++ b/generate-manpage.sh
@@ -34,6 +34,7 @@ for root in \
     /usr/share/sgml/docbook/stylesheet/xsl/nwalsh \
     /usr/share/xml/docbook/stylesheet/docbook-xs \
     /usr/share/xml/docbook/stylesheet/docbook-xsl-nons \
+    /usr/share/xml/docbook/xsl-stylesheets-nons \
     /usr/share/xml/docbook/xsl-stylesheets \
     /usr/share/sgml/docbook/xsl-stylesheets \
     /usr/share/xml/docbook/xsl-stylesheets-*-nons \


### PR DESCRIPTION
Right now (arch dockbook-xsl at 1.79.2-9), there is a `/usr/share/xml/docbook/xsl-stylesheets-nons/` symbolic link to `/usr/share/xml/docbook/xsl-stylesheets-1.79.2-nons/`